### PR TITLE
refactor: consolidate multiple print line used in display logo into one

### DIFF
--- a/src/utils/__test__/displayLogo.test.ts
+++ b/src/utils/__test__/displayLogo.test.ts
@@ -1,4 +1,4 @@
-import { cyan, yellow } from '../deps.ts';
+import { Rhum } from '../../deps.ts';
 
 const separator = '-------------------------------------------------------------------------------------';
 const asciiTitle = `
@@ -8,17 +8,38 @@ const asciiTitle = `
   ██ ███ ██ ██ ██  ██  ██ ██      ██      ██   ██ ██ ██   ██     ██      ██      ██
    ███ ███  ██ ██   ██ ██ ██      ███████ ██████  ██ ██   ██      ██████ ███████ ██
 `;
-const fullLogo = `
-${yellow(separator)}
-${cyan(asciiTitle)}
-${yellow(separator)}
+
+const expected = `
+\x1b[33m${separator}\x1b[39m
+\x1b[36m${asciiTitle}\x1b[39m
+\x1b[33m${separator}\x1b[39m
 `;
 
-/**
- * Display the application logo (ASCII).
- */
-const displayLogo = (): void => {
-  console.log(fullLogo);
-};
+Rhum.testPlan('displayLogo.ts', () => {
+  Rhum.testSuite('displayLogo()', () => {
+    Rhum.testCase('should display app logo', async () => {
+      const p = await Deno.run({
+        cmd: [
+          'deno',
+          'eval',
+          '--quiet',
+          'import displayLogo from \'./src/utils/displayLogo.ts\'; displayLogo();'
+        ],
+        stdout: 'piped',
+        stderr: 'piped'
+      });
+      const status = await p.status();
 
-export default displayLogo;
+      const stdout = new TextDecoder().decode(await p.output());
+      const stderr = new TextDecoder().decode(await p.stderrOutput());
+      p.close();
+
+      Rhum.asserts.assertEquals(stderr, '');
+      Rhum.asserts.assertEquals(stdout, `${expected}\n`);
+      Rhum.asserts.assertEquals(status.code, 0);
+      Rhum.asserts.assertEquals(status.success, true);
+    });
+  });
+});
+
+Rhum.run();


### PR DESCRIPTION
<!-- Please fill in below sections, include details as much as possible -->
<!-- Leave "N/A" to any non-applicable sections instead of leaving them blank -->

## Description
<!---- Describe your changes in detail ---->
This PR aims to simplify the code of `displayLogo()` by consolidating multiple `console.log()` into one.

## How has this been tested?
<!---- Please describe in detail how you tested your changes ---->
1. Test case have been written for displayLogo()
2. Run `make dev` to validate the changes

## Types of changes
<!---- Put an `x` in the box that apply ---->
<!---- In most cases the option chosen should match the prefix of commit message ---->
<!---- (Try not to select more than one option as we don't recommend mixing task in one commit) ---->
- [ ] New feature - `feat`
- [ ] Bug fix - `fix`
- [x] Refactor - `refactor`
- [ ] Test cases - `test`
- [ ] Other(s): <!-- Fill the type of changes here -->

## Checklist:
- [x] Test cases have been written for utilities.
- [ ] I have test my code on different platforms (Windows, MacOS, Linux).

## Remarks
<!---- Leave your remarks if applicable ---->
N/A
