### PR TITLE
refactor: rename object keys returned from getTerminalSize()

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -40,7 +40,7 @@ const normalizedArgs: { [key: string]: string | undefined } = {};
  * Display usage and available options for this CLI.
  */
 const displayHelp = async (): Promise<void> => {
-  const { terminalWidth } = await getTerminalSize();
+  const { columns: terminalWidth } = await getTerminalSize();
   const descriptionMaxLength = Math.floor((terminalWidth - 20) / 2);
 
   const cliDescription: string = bold(green('Search anything on Wikipedia from your terminal'));

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,8 +20,8 @@ export type OptionsType = {
 
 /* getTerminalSize */
 export interface ITerminalSize {
-  terminalWidth: number;
-  terminalHeight: number;
+  columns: number;
+  rows: number;
 }
 
 /* makeRequest */

--- a/src/utils/__test__/getTerminalSize.test.ts
+++ b/src/utils/__test__/getTerminalSize.test.ts
@@ -1,0 +1,25 @@
+import getTerminalSize from '../getTerminalSize.ts';
+import { Rhum } from '../../deps.ts';
+
+// FIXME: Find a proper way to run it on Github action:
+// https://github.com/actions/runner/issues/241
+if (Deno.isatty(Deno.stdout.rid)) {
+  Rhum.testPlan('getTerminalSize.ts', () => {
+    Rhum.testSuite('getTerminalSize()', () => {
+      Rhum.testCase('should return an object which contains terminal rows and columns', async () => {
+        const expected = await Deno.consoleSize(Deno.stdout.rid);
+        const terminalSize = await getTerminalSize();
+
+        Rhum.asserts.assertEquals(typeof terminalSize === 'object', true);
+        Rhum.asserts.assertEquals(Number.isInteger(terminalSize.columns), true);
+        Rhum.asserts.assertEquals(terminalSize.columns, expected.columns);
+        Rhum.asserts.assertEquals(Number.isInteger(terminalSize.rows), true);
+        Rhum.asserts.assertEquals(terminalSize.rows, expected.rows);
+      });
+    });
+  });
+} else {
+  console.log('Skip running getTerminalSize() test as environment is not a TTY');
+}
+
+Rhum.run();

--- a/src/utils/getTerminalSize.ts
+++ b/src/utils/getTerminalSize.ts
@@ -3,14 +3,9 @@ import { ITerminalSize } from '../types.ts';
 /**
  * Returns the current terminal width (columns) and height (rows).
  */
-const getTerminalSize = async (): Promise<ITerminalSize> => {
-  // FIXME: This is an unstable feature for getting terminal size
-  const {
-    columns: terminalWidth,
-    rows: terminalHeight
-  } = await Deno.consoleSize(Deno.stdout.rid);
-
-  return { terminalWidth, terminalHeight };
-};
+// FIXME: This is an unstable feature for getting terminal size
+const getTerminalSize = async (): Promise<
+  ITerminalSize
+> => (await Deno.consoleSize(Deno.stdout.rid));
 
 export default getTerminalSize;


### PR DESCRIPTION
<!-- Please fill in below sections, include details as much as possible -->
<!-- Leave "N/A" to any non-applicable sections instead of leaving them blank -->

## Description
<!---- Describe your changes in detail ---->
Rename object key from `terminalWidth` and `terminalHeight` to `columns` and `rows`, so that calling `const terminalSize = await getTerminalSize();` will not have unnecessary context like `terminalSize.terminalWidth`.

See more about clean code practices at [https://github.com/ryanmcdermott/clean-code-javascript#dont-add-unneeded-context](https://github.com/ryanmcdermott/clean-code-javascript#dont-add-unneeded-context)

## How has this been tested?
<!---- Please describe in detail how you tested your changes ---->
1. Test case have been written for `getTerminalSize()`
2. Run `make dev` to test the app

## Types of changes
<!---- Put an `x` in the box that apply ---->
- [ ] New feature - `feat`
- [ ] Bug fix - `fix`
- [x] Refactor - `refactor`
- [ ] Test cases - `test`
- [ ] Other(s): <!-- Fill the type of changes here -->

## Checklist:
- [x] Test cases have been written for utilities.
- [ ] I have test my code on different platforms (Windows, MacOS, Linux).

## Remarks
<!---- Leave your remarks if applicable ---->
Although a test has been written, it failed to run on Github action, which the `Deno.consoleSize(Deno.stdout.rid)` seems to require the environment to be a TTY. So a hacky if else to detect if the environment is a TTY is written to conditionally trigger this test.

Related issue: https://github.com/actions/runner/issues/241
