### PR TITLE
refactor: reduce variables used in getConfigurationFilePath

### DIFF
--- a/src/utils/__test__/getConfigurationFilePath.test.ts
+++ b/src/utils/__test__/getConfigurationFilePath.test.ts
@@ -1,0 +1,12 @@
+import getConfigurationFilePath from '../getConfigurationFilePath.ts';
+import { Rhum } from '../../deps.ts';
+
+Rhum.testPlan('getConfigurationFilePath.ts', () => {
+  Rhum.testSuite('getConfigurationFilePath()', () => {
+    Rhum.testCase('should return configuration file path', () => {
+      Rhum.asserts.assertEquals(getConfigurationFilePath(), `${Deno.env.get('HOME') ?? '.'}/.wiki-cli.json`);
+    });
+  });
+});
+
+Rhum.run();

--- a/src/utils/getConfigurationFilePath.ts
+++ b/src/utils/getConfigurationFilePath.ts
@@ -2,8 +2,7 @@
  * Get configuration file path.
  */
 const getConfigurationFilePath = (): string => {
-  const homeEnviroment: string | undefined = Deno.env.get('HOME');
-  const homePath = homeEnviroment ?? '.';
+  const homePath: string = Deno.env.get('HOME') ?? '.';
   return `${homePath}/.wiki-cli.json`;
 };
 


### PR DESCRIPTION
<!-- Please fill in below sections, include details as much as possible -->
<!-- Leave "N/A" to any non-applicable sections instead of leaving them blank -->

## Description
<!---- Describe your changes in detail ---->
Remove unnecessary variable used in `getConfigurationFilePath()`.

## How has this been tested?
<!---- Please describe in detail how you tested your changes ---->
1. Test case have been written for `getConfigurationFilePath()`
2. Run `make dev` to test locally

## Types of changes
<!---- Put an `x` in the box that apply ---->
- [ ] New feature - `feat`
- [ ] Bug fix - `fix`
- [x] Refactor - `refactor`
- [ ] Test cases - `test`
- [ ] Other(s): <!-- Fill the type of changes here -->

## Checklist:
- [x] Test cases have been written for utilities.
- [ ] I have test my code on different platforms (Windows, MacOS, Linux).

## Remarks
<!---- Leave your remarks if applicable ---->
N/A
